### PR TITLE
fix for a bug found while testing

### DIFF
--- a/Solutions/Digital Shadows/Analytic Rules/Digital_Shadows_incident_creation_exclude.yaml
+++ b/Solutions/Digital Shadows/Analytic Rules/Digital_Shadows_incident_creation_exclude.yaml
@@ -50,7 +50,7 @@ properties:
     createIncident: true
     groupingConfiguration:
       enabled: true
-      reopenClosedIncident: false
+      reopenClosedIncident: true
       lookbackDuration: P7D
       matchingMethod: Selected
       groupByEntities: []

--- a/Solutions/Digital Shadows/Analytic Rules/Digital_Shadows_incident_creation_include.yaml
+++ b/Solutions/Digital Shadows/Analytic Rules/Digital_Shadows_incident_creation_include.yaml
@@ -50,7 +50,7 @@ properties:
     createIncident: true
     groupingConfiguration:
       enabled: true
-      reopenClosedIncident: false
+      reopenClosedIncident: true
       lookbackDuration: P7D
       matchingMethod: Selected
       groupByEntities: []


### PR DESCRIPTION
If an incident is closed and then it is opened in next invocation, a duplicate azure sentinel incident gets created. Fixed this by reopening the closed incident(if it is in the lookback period, i.e. 7 days) from analytic rule.